### PR TITLE
Emergency Fix

### DIFF
--- a/node-backend/Dockerfile
+++ b/node-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:lts
 
 EXPOSE 3001
 

--- a/react-app/Dockerfile
+++ b/react-app/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:14
+FROM node:lts
+
 # Create app directory
 WORKDIR /opt/src/app
 # Install app dependencies


### PR DESCRIPTION
I updated the node image because the project would not build. 

Problem:
The project will not build.

Cause:
The node:14 image is not compatible with npm@latest.

Fix:
Replace the node:14 image with node:lts.

Results:
The project builds and operates as intended. 